### PR TITLE
Support blob types

### DIFF
--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageAdapter.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageAdapter.java
@@ -98,7 +98,11 @@ public class TablePageAdapter {
 
             for (int col = 0; col < cursor.getColumnCount(); col++) {
                 TextView textView = new TextView(mContext);
-                textView.setText(cursor.getString(col));
+                if (cursor.getType(col) == Cursor.FIELD_TYPE_BLOB) {
+                    textView.setText("(data)");
+                } else {
+                    textView.setText(cursor.getString(col));
+                }
                 textView.setPadding(mPaddingPx, mPaddingPx / 2, mPaddingPx, mPaddingPx / 2);
 
                 if (alternate) {


### PR DESCRIPTION
When first trying this on my app it crashed switching to content view on one of my tables, trying to convert a `blob` to a `string`. In a manner similar to [SQLite Editor](https://play.google.com/store/apps/details?id=com.speedsoftware.sqleditor) replace `blob` text with `"(data)"`.
