### PR TITLE
added support for showing foreign keys and indexes in table info

### DIFF
--- a/ExampleApp/src/main/java/im/dino/dbview/exampleapp/models/Article.java
+++ b/ExampleApp/src/main/java/im/dino/dbview/exampleapp/models/Article.java
@@ -12,7 +12,7 @@ import java.util.Calendar;
 @Table(name = "articles")
 public class Article extends Model {
 
-    @Column(name = "title")
+    @Column(name = "title", index = true)
     public String title;
 
     @Column(name = "text")

--- a/ExampleApp/src/main/java/im/dino/dbview/exampleapp/models/User.java
+++ b/ExampleApp/src/main/java/im/dino/dbview/exampleapp/models/User.java
@@ -10,7 +10,7 @@ import com.activeandroid.annotation.Table;
 @Table(name = "users")
 public class User extends Model {
 
-    @Column(name = "first_name")
+    @Column(name = "first_name", index = true)
     public String firstName;
 
     @Column(name = "last_name")

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageAdapter.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageAdapter.java
@@ -17,6 +17,7 @@ import im.dino.dbinspector.helpers.CursorOperation;
 import im.dino.dbinspector.helpers.DatabaseHelper;
 import im.dino.dbinspector.helpers.DisplayHelper;
 import im.dino.dbinspector.R;
+import im.dino.dbinspector.helpers.PragmaType;
 
 /**
  * Created by dino on 27/02/14.
@@ -37,6 +38,8 @@ public class TablePageAdapter {
 
     private int paddingPx;
 
+    private String pragma;
+
     public TablePageAdapter(Context context, File databaseFile, String tableName, int startPage) {
 
         this.context = context;
@@ -52,12 +55,23 @@ public class TablePageAdapter {
         position = this.rowsPerPage * startPage;
     }
 
-    public List<TableRow> getStructure() {
+    public List<TableRow> getByPragma(PragmaType pragmaType) {
+        switch (pragmaType) {
+            case FOREIGN_KEY:
+                pragma = String.format(DatabaseHelper.PRAGMA_FORMAT_FOREIGN_KEYS, tableName);
+                break;
+            case INDEX_LIST:
+                pragma = String.format(DatabaseHelper.PRAGMA_FORMAT_INDEX, tableName);
+                break;
+            case TABLE_INFO:
+                pragma = String.format(DatabaseHelper.PRAGMA_FORMAT_TABLE_INFO, tableName);
+                break;
+        }
 
         CursorOperation<List<TableRow>> operation = new CursorOperation<List<TableRow>>(databaseFile) {
             @Override
             public Cursor provideCursor(SQLiteDatabase database) {
-                return database.rawQuery(String.format(DatabaseHelper.PRAGMA_FORMAT, tableName), null);
+                return database.rawQuery(pragma, null);
             }
 
             @Override

--- a/dbinspector/src/main/java/im/dino/dbinspector/helpers/DatabaseHelper.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/helpers/DatabaseHelper.java
@@ -48,7 +48,11 @@ public class DatabaseHelper {
     public static final String TABLE_LIST_QUERY
             = "SELECT name FROM sqlite_master WHERE type='table'";
 
-    public static final String PRAGMA_FORMAT = "PRAGMA table_info(%s)";
+    public static final String PRAGMA_FORMAT_TABLE_INFO = "PRAGMA table_info(%s)";
+
+    public static final String PRAGMA_FORMAT_INDEX = "PRAGMA index_list(%s)";
+
+    public static final String PRAGMA_FORMAT_FOREIGN_KEYS = "PRAGMA foreign_key_list(%s)";
 
     public static List<File> getDatabaseList(Context context) {
         List<File> databaseList = new ArrayList<>();

--- a/dbinspector/src/main/java/im/dino/dbinspector/helpers/PragmaType.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/helpers/PragmaType.java
@@ -1,0 +1,13 @@
+package im.dino.dbinspector.helpers;
+
+/**
+ * Created by zeljkoplesac on 16/03/15.
+ */
+public enum PragmaType {
+
+    TABLE_INFO,
+
+    FOREIGN_KEY,
+
+    INDEX_LIST;
+}

--- a/dbinspector/src/main/res/values/dbinspector_strings.xml
+++ b/dbinspector/src/main/res/values/dbinspector_strings.xml
@@ -12,6 +12,8 @@
     <string name="dbinspector_pref_key_rows_per_page">prefs_key_row_per_page</string>
     <string name="dbinspector_rows_per_page">Rows per page</string>
     <string name="dbinspector_databases">Databases</string>
+    <string name="dbinspector_foreign_keys">Foreign keys</string>
+    <string name="dbinspector_indexes">Indexes</string>
 
     <string name="dbinspector_rows_per_page_default">10</string>
     <string-array name="dbinspector_rows_per_page_options">


### PR DESCRIPTION
Added support for showing foreign keys and indexes in table info fragment.
Pragmas are now defined in external PragmaType enum, which is used for querying the database.