### PR TITLE
Set taskAffinity to DbInspectorActivity

### DIFF
--- a/dbinspector/src/main/AndroidManifest.xml
+++ b/dbinspector/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
                 android:name="im.dino.dbinspector.activities.DbInspectorActivity"
                 android:label="@string/dbinspector_app_name"
                 android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
-                android:icon="@drawable/dbinspector_ic_launcher">
+                android:icon="@drawable/dbinspector_ic_launcher"
+                android:taskAffinity="im.dino.dbinspector">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
Resolve an issue where the launcher would get confused and launch the original app instead of the DB Inspector activity, and vice-versa