### PR TITLE
Support split-screen view on Nougat

### DIFF
--- a/dbinspector/src/main/java/im/dino/dbinspector/DbInspector.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/DbInspector.java
@@ -1,0 +1,14 @@
+package im.dino.dbinspector;
+
+import android.content.Context;
+import android.content.Intent;
+
+import im.dino.dbinspector.activities.DbInspectorActivity;
+
+public final class DbInspector {
+
+    public static Intent getLaunchIntent(Context context) {
+        return DbInspectorActivity.launch(context)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
+}

--- a/dbinspector/src/main/java/im/dino/dbinspector/activities/DbInspectorActivity.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/activities/DbInspectorActivity.java
@@ -1,5 +1,7 @@
 package im.dino.dbinspector.activities;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
@@ -9,6 +11,10 @@ import im.dino.dbinspector.R;
 import im.dino.dbinspector.fragments.DatabaseListFragment;
 
 public class DbInspectorActivity extends AppCompatActivity {
+
+    public static Intent launch(Context context) {
+        return new Intent(context, DbInspectorActivity.class);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Thanks so much for creating such an useful library!

One thing I missed while integrating it was the ability to launch the db-explorer activity right next to my app, and see data being modified in real-time, without having to go back-and-forth with the Recents button.

This PR allows you to run the client app and the `DbInspectorActivity` at the same time, side-by-side.

Usage: on any `View`, call:

``` java
getContext()
    .startActivity(DbInspector.getLaunchIntent(getContext()))
```
and it'll be launched in a different Task.

I'd be very happy to have this on the library. Let me know if you need any changes.