### PR TITLE
Update dependency configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a simple way to view the contents of the in-app database for debugging 
 Add the library as a dependency to your ```build.gradle```
 
 ```groovy
-debugCompile 'im.dino:dbinspector:3.4.1@aar'
+debugImplementation 'im.dino:dbinspector:3.4.1@aar'
 ```
 
 Check the latest version on [Maven Central](http://search.maven.org/#search|ga|1|g%3A%22im.dino%22%20a%3A%22dbinspector%22).


### PR DESCRIPTION
#### What does this PR do ?
Update project's dependency configuration from `debugCompile` to `debugImplementation`

#### Description of tasks to be completed
Update project's dependency configuration in the Project's `README.md`. This is to ensure that users of this project as their project's dependency do not get the compile time error below. 
`debugCompile` has been deprecated as a `build configuration` in Android studio and has been replaced with `debugImplementation`.

Learn more about this upgrade
[https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations)

Screen shot
<img width="1328" alt="screen shot 2019-02-09 at 4 02 17 pm" src="https://user-images.githubusercontent.com/30831276/52523801-7a975c80-2c95-11e9-9169-30a18d147077.png">
