### PR TITLE
Feature: custom table format (long text, timestamp, etc.)

### DIFF
--- a/ExampleApp/src/debug/java/im/dino/dbview/exampleapp/ExampleTablePageFormatterFactory.java
+++ b/ExampleApp/src/debug/java/im/dino/dbview/exampleapp/ExampleTablePageFormatterFactory.java
@@ -1,0 +1,34 @@
+package im.dino.dbview.exampleapp;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import im.dino.dbinspector.adapters.TablePageFormatters;
+import im.dino.dbinspector.adapters.TablePageFormatters.ICellViewFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.ITablesFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.LongTextViewFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.TablesFormatter;
+
+import static im.dino.dbinspector.adapters.TablePageFormatters.dpToPx;
+import static im.dino.dbinspector.adapters.TablePageFormatters.shortTimeStamp;
+
+// Optional app-specific database table display customization in DbInspector
+class ExampleTablePageFormatterFactory implements TablePageFormatters.ITablesFormatterFactory {
+
+    public static void init() {
+        TablePageFormatters.setTablesFormatterFactory(new ExampleTablePageFormatterFactory());
+    }
+
+    @Override
+    public ITablesFormatter create(Context context) {
+        final int defaultMaxWidth = dpToPx(200, context);
+
+        // truncate long text if needed
+        final ICellViewFormatter vDefault = new LongTextViewFormatter(defaultMaxWidth, TextUtils.TruncateAt.END);
+
+        return new TablesFormatter(
+                "articles", new TablePageFormatters.RowFormatter()
+                .setValueFormatters("pubblished_at", shortTimeStamp) // convert long timestamp to human-readable form
+        ).setDefaultCellViewFormatter(vDefault);
+    }
+}

--- a/ExampleApp/src/main/java/im/dino/dbview/exampleapp/ExampleApp.java
+++ b/ExampleApp/src/main/java/im/dino/dbview/exampleapp/ExampleApp.java
@@ -1,9 +1,22 @@
 package im.dino.dbview.exampleapp;
 
+import android.app.Application;
+import android.content.Context;
+import android.text.TextUtils.TruncateAt;
+
 import com.activeandroid.ActiveAndroid;
 import com.squareup.leakcanary.LeakCanary;
 
-import android.app.Application;
+import im.dino.dbinspector.adapters.TablePageFormatters;
+import im.dino.dbinspector.adapters.TablePageFormatters.ICellViewFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.ITablesFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.ITablesFormatterFactory;
+import im.dino.dbinspector.adapters.TablePageFormatters.LongTextViewFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.RowFormatter;
+import im.dino.dbinspector.adapters.TablePageFormatters.TablesFormatter;
+
+import static im.dino.dbinspector.adapters.TablePageFormatters.dpToPx;
+import static im.dino.dbinspector.adapters.TablePageFormatters.shortTimeStamp;
 
 /**
  * Created by dino on 02/06/15.
@@ -15,6 +28,23 @@ public class ExampleApp extends Application {
         super.onCreate();
         LeakCanary.install(this);
         ActiveAndroid.initialize(this);
+
+        // Add optional app-specific database table display customization
+        TablePageFormatters.setTablesFormatterFactory(new ExampleTablePageFormatterFactory());
     }
 
+}
+
+class ExampleTablePageFormatterFactory implements ITablesFormatterFactory {
+    @Override
+    public ITablesFormatter create(Context context) {
+        final int defaultMaxWidth = dpToPx(200, context);
+
+        final ICellViewFormatter vDefault = new LongTextViewFormatter(defaultMaxWidth, TruncateAt.END); // truncate long text if needed
+
+        return new TablesFormatter(
+                "articles", new RowFormatter()
+                .setValueFormatters("pubblished_at", shortTimeStamp) // convert long timestamp to human-readable form
+        ).setDefaultCellViewFormatter(vDefault);
+    }
 }

--- a/ExampleApp/src/main/java/im/dino/dbview/exampleapp/ExampleApp.java
+++ b/ExampleApp/src/main/java/im/dino/dbview/exampleapp/ExampleApp.java
@@ -1,22 +1,9 @@
 package im.dino.dbview.exampleapp;
 
 import android.app.Application;
-import android.content.Context;
-import android.text.TextUtils.TruncateAt;
 
 import com.activeandroid.ActiveAndroid;
 import com.squareup.leakcanary.LeakCanary;
-
-import im.dino.dbinspector.adapters.TablePageFormatters;
-import im.dino.dbinspector.adapters.TablePageFormatters.ICellViewFormatter;
-import im.dino.dbinspector.adapters.TablePageFormatters.ITablesFormatter;
-import im.dino.dbinspector.adapters.TablePageFormatters.ITablesFormatterFactory;
-import im.dino.dbinspector.adapters.TablePageFormatters.LongTextViewFormatter;
-import im.dino.dbinspector.adapters.TablePageFormatters.RowFormatter;
-import im.dino.dbinspector.adapters.TablePageFormatters.TablesFormatter;
-
-import static im.dino.dbinspector.adapters.TablePageFormatters.dpToPx;
-import static im.dino.dbinspector.adapters.TablePageFormatters.shortTimeStamp;
 
 /**
  * Created by dino on 02/06/15.
@@ -29,22 +16,11 @@ public class ExampleApp extends Application {
         LeakCanary.install(this);
         ActiveAndroid.initialize(this);
 
-        // Add optional app-specific database table display customization
-        TablePageFormatters.setTablesFormatterFactory(new ExampleTablePageFormatterFactory());
+        // Add optional app-specific database table display customization with DbInspector.
+        // The actual definition is in debug source tree, given DbInspector is included in debug builds only.
+        // Release source tree has a no-op implementation.
+        ExampleTablePageFormatterFactory.init();
     }
 
 }
 
-class ExampleTablePageFormatterFactory implements ITablesFormatterFactory {
-    @Override
-    public ITablesFormatter create(Context context) {
-        final int defaultMaxWidth = dpToPx(200, context);
-
-        final ICellViewFormatter vDefault = new LongTextViewFormatter(defaultMaxWidth, TruncateAt.END); // truncate long text if needed
-
-        return new TablesFormatter(
-                "articles", new RowFormatter()
-                .setValueFormatters("pubblished_at", shortTimeStamp) // convert long timestamp to human-readable form
-        ).setDefaultCellViewFormatter(vDefault);
-    }
-}

--- a/ExampleApp/src/release/java/im/dino/dbview/exampleapp/ExampleTablePageFormatterFactory.java
+++ b/ExampleApp/src/release/java/im/dino/dbview/exampleapp/ExampleTablePageFormatterFactory.java
@@ -1,0 +1,10 @@
+package im.dino.dbview.exampleapp;
+
+class ExampleTablePageFormatterFactory {
+    public static void init() {
+        // No-op in release, see the version in debug source tree for actual implementation.
+        //
+        // This entry point method MUST be devoid of any references to dbinspector, so that
+        // dbinspector can be included as as debug-only dependency.
+    }
+}

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -124,5 +124,9 @@
         <!--module name="FinalParameters"/-->
         <!--module name="TodoComment"/-->
         <module name="UpperEll"/>
+
+        <module name="SuppressWarningsHolder" />
     </module>
+    <!-- support @SuppressWarnings annotation -->
+    <module name="SuppressWarningsFilter" />
 </module>

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -1,0 +1,233 @@
+package im.dino.dbinspector.adapters;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.util.ArrayMap;
+import android.text.TextUtils;
+import android.widget.TextView;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Map;
+
+public class TablePageFormatters {
+    private static ITablesFormatter nooOpTablesFormatter = new ITablesFormatter() {
+        @Nullable
+        @Override
+        public IRowFormatter getRowFormatterOfTable(String tableName) {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public ICellViewFormatter getDefaultCellViewFormatter() {
+            return null;
+        }
+    };
+
+    private static ITablesFormatterFactory tablesFormatterFactory = null;
+
+    public static void setTablesFormatterFactory(ITablesFormatterFactory tablesFormatterFactory) {
+        TablePageFormatters.tablesFormatterFactory = tablesFormatterFactory;
+    }
+
+    @NonNull
+    public static ITablesFormatter createTablesFormatter(Context context) {
+        if (tablesFormatterFactory != null) {
+            return tablesFormatterFactory.create(context);
+        } else {
+            return nooOpTablesFormatter;
+        }
+    }
+
+    private TablePageFormatters() {} // the class serves as a namespace for the interfaces and default helpers
+
+    /**
+     * Provider formatter for a collection of tables
+     */
+    public interface ITablesFormatter {
+        @Nullable
+        IRowFormatter getRowFormatterOfTable(String tableName);
+
+        @Nullable
+        ICellViewFormatter getDefaultCellViewFormatter();
+    }
+
+    public interface ITablesFormatterFactory {
+        @NonNull
+        ITablesFormatter create(@NonNull Context context);
+    }
+
+    /**
+     * Format the values of a table row
+     */
+    public interface IRowFormatter {
+        @Nullable
+        ICellValueFormatter getCellValueFormatter(String columnName);
+        ICellViewFormatter getHeaderViewFormatter(String columnName);
+        ICellViewFormatter getCellViewFormatter(String columnName);
+    }
+
+    public interface ICellValueFormatter {
+        @NonNull
+        String formatValue(Cursor cursor, int col);
+    }
+
+    public interface ICellViewFormatter {
+        void formatView(TextView view);
+    }
+
+    public static class TablesFormatter implements  ITablesFormatter {
+        private final Map<String, IRowFormatter> config = new ArrayMap<String, IRowFormatter>();
+        @Nullable
+        private ICellViewFormatter defaultCellViewFormatter = null;
+
+        public TablesFormatter(Object... tableNameFormatterPairs) {
+            for (int i = 0; i < tableNameFormatterPairs.length; i += 2) {
+                try {
+                    String tableName = (String) tableNameFormatterPairs[i];
+                    IRowFormatter formatter = (IRowFormatter) tableNameFormatterPairs[i + 1];
+                    config.put(tableName, formatter);
+                } catch (ClassCastException cce) {
+                    throw new IllegalArgumentException("TablesFormatter() - arguments must be in tableName - rowFormatter pairs. Incorrect type at " + i, cce);
+                }
+            }
+        }
+
+        public TablesFormatter setDefaultCellViewFormatter(@Nullable ICellViewFormatter defaultCellViewFormatter) {
+            this.defaultCellViewFormatter = defaultCellViewFormatter;
+            return this;
+        }
+
+        @Nullable
+        @Override
+        public IRowFormatter getRowFormatterOfTable(String tableName) {
+            return config.get(tableName);
+        }
+
+        @Nullable
+        @Override
+        public ICellViewFormatter getDefaultCellViewFormatter() {
+            return defaultCellViewFormatter;
+        }
+    }
+
+    public static class RowFormatter implements IRowFormatter {
+        private final Map<String, ICellValueFormatter> valueConfig = new ArrayMap<String, ICellValueFormatter>();
+        private final Map<String, ICellViewFormatter> headerViewConfig = new ArrayMap<String, ICellViewFormatter>();
+        private final Map<String, ICellViewFormatter> viewConfig = new ArrayMap<String, ICellViewFormatter>();
+
+        public RowFormatter() {}
+
+        public RowFormatter setValueFormatters(Object... columnNameFormatterPairs) {
+            valueConfig.clear();
+            for (int i = 0; i < columnNameFormatterPairs.length; i += 2) {
+                try {
+                    String columnName = (String) columnNameFormatterPairs[i];
+                    ICellValueFormatter cellFormatter = (ICellValueFormatter) columnNameFormatterPairs[i + 1];
+                    valueConfig.put(columnName, cellFormatter);
+                } catch (ClassCastException cce) {
+                    throw new IllegalArgumentException("Arguments must be in columnName - cellFormatter pairs. Incorrect type at " + i, cce);
+                }
+            }
+            return this;
+        }
+
+        public RowFormatter setViewFormatters(Object... columnNameFormatterPairs) {
+            headerViewConfig.clear();
+            viewConfig.clear();
+            for (int i = 0; i < columnNameFormatterPairs.length; i += 3) {
+                try {
+                    String columnName = (String) columnNameFormatterPairs[i];
+                    ICellViewFormatter headerFormatter = (ICellViewFormatter) columnNameFormatterPairs[i + 1];
+                    ICellViewFormatter cellFormatter = (ICellViewFormatter) columnNameFormatterPairs[i + 2];
+
+                    headerViewConfig.put(columnName, headerFormatter);
+                    viewConfig.put(columnName, cellFormatter);
+                } catch (ClassCastException cce) {
+                    throw new IllegalArgumentException("Arguments must be in columnName - headerViewFormatter - cellViewFormatter triples. Incorrect type at " + i, cce);
+                }
+            }
+            return this;
+        }
+
+        @Nullable
+        @Override
+        public ICellValueFormatter getCellValueFormatter(String columnName) {
+            return valueConfig.get(columnName);
+        }
+
+        @Override
+        public ICellViewFormatter getHeaderViewFormatter(String columnName) {
+            return headerViewConfig.get(columnName);
+        }
+
+        @Override
+        public ICellViewFormatter getCellViewFormatter(String columnName) {
+            return viewConfig.get(columnName);
+        }
+    }
+
+    //
+    // Formatter classes / instances for conveniences
+    //
+
+    public static class DateTimeFormatter implements ICellValueFormatter {
+        //    private static final DateFormat formatter = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss.SSS");
+        private final DateFormat formatter;
+
+        public DateTimeFormatter(String formatPattern) {
+            formatter = new SimpleDateFormat(formatPattern);
+        }
+
+        @NonNull
+        @Override
+        final public String formatValue(Cursor cursor, int col) {
+            long value = cursor.getLong(col);
+            return (value > 0) ? formatter.format(value) : "";
+        }
+    };
+
+    /**
+     * Helper to format a View that is expected to contain long text, by setting
+     * max with and truncation.
+     */
+    public static class LongTextViewFormatter implements ICellViewFormatter {
+        private final int maxWidthInPx;
+        @Nullable
+        private final TextUtils.TruncateAt ellipsizeWhere;
+
+        public LongTextViewFormatter(int maxWidthInPx, @Nullable TextUtils.TruncateAt ellipsizeWhere) {
+            this.maxWidthInPx = maxWidthInPx;
+            this.ellipsizeWhere = ellipsizeWhere;
+        }
+
+        @Override
+        public void formatView(TextView view) {
+            view.setMaxWidth(maxWidthInPx);
+            view.setMaxLines(1);
+            view.setEllipsize(ellipsizeWhere);
+        }
+    }
+
+    /**
+     * Use cases: express max width of a view in the unit of dp
+     * @return the pixels of the given amount of dp
+     */
+    public static int dpToPx(int dp, @NonNull Context context) {
+        return Math.round(dp * context.getResources().getDisplayMetrics().density);
+    }
+
+    /**
+     * Convert a <code>long</code> timestamp to a short date in YY-MM-dd
+     */
+    public static final ICellValueFormatter shortDate = new DateTimeFormatter("YY-MM-dd");
+
+    /**
+     * Convert a <code>long</code> timestamp to a short timestamp string
+     */
+    public static final ICellValueFormatter shortTimeStamp = new DateTimeFormatter("YY-MM-dd HH:mm:ss");
+
+}

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -223,11 +223,11 @@ public class TablePageFormatters {
     /**
      * Convert a <code>long</code> timestamp to a short date in YY-MM-dd
      */
-    public static final ICellValueFormatter shortDate = new DateTimeFormatter("YY-MM-dd");
+    public static final ICellValueFormatter shortDate = new DateTimeFormatter("yy-MM-dd");
 
     /**
      * Convert a <code>long</code> timestamp to a short timestamp string
      */
-    public static final ICellValueFormatter shortTimeStamp = new DateTimeFormatter("YY-MM-dd HH:mm:ss");
+    public static final ICellValueFormatter shortTimeStamp = new DateTimeFormatter("yy-MM-dd HH:mm:ss");
 
 }

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -14,6 +14,9 @@ import java.text.SimpleDateFormat;
 import java.util.Map;
 
 public class TablePageFormatters {
+
+    private TablePageFormatters() { } // the class serves as a namespace for the interfaces and default helpers
+
     private static ITablesFormatter nooOpTablesFormatter = new ITablesFormatter() {
         @Nullable
         @Override
@@ -30,6 +33,9 @@ public class TablePageFormatters {
 
     private static ITablesFormatterFactory tablesFormatterFactory = null;
 
+    /**
+     * Used by apps that integrated with DbInspector to customize content table output.
+     */
     public static void setTablesFormatterFactory(ITablesFormatterFactory tablesFormatterFactory) {
         TablePageFormatters.tablesFormatterFactory = tablesFormatterFactory;
     }
@@ -43,10 +49,8 @@ public class TablePageFormatters {
         }
     }
 
-    private TablePageFormatters() { } // the class serves as a namespace for the interfaces and default helpers
-
     /**
-     * Provider formatter for a collection of tables.
+     * Provide formatters that can style / format the output of a collection of tables.
      */
     public interface ITablesFormatter {
         @Nullable
@@ -72,11 +76,26 @@ public class TablePageFormatters {
     }
 
     public interface ICellValueFormatter {
+        /**
+         *
+         * Given the cell value defined by the cursor and column position,
+         * return a formatted value, e.g., convert a unix epoch time in <code>long</code>
+         * to human-readable string.
+         *
+         * The caller should use the cursor to access the cell value only, e.g.,
+         * <code>cursor.getLong(col)</code>, and MUST not change its state, e.g.,
+         * moving to the next row.
+         */
         @NonNull
         String formatValue(Cursor cursor, int col);
     }
 
     public interface ICellViewFormatter {
+        /**
+         * Styles a given cell, e.g., width, text appearance, etc.
+         * It should not change the actual cell value, which is customized
+         * with a #ICellValueFormatter
+         */
         void formatView(TextView view);
     }
 
@@ -85,6 +104,12 @@ public class TablePageFormatters {
         @Nullable
         private ICellViewFormatter defaultCellViewFormatter = null;
 
+        /**
+         * Specify the formatters for a collection of tables.
+         *
+         * @param tableNameFormatterPairs a list of #java.lang.String tableName , #IRowFormatter rowFormatter pairs,
+         *                                defining the customization for the tables
+         */
         public TablesFormatter(Object... tableNameFormatterPairs) {
             for (int i = 0; i < tableNameFormatterPairs.length; i += 2) {
                 try {
@@ -97,6 +122,10 @@ public class TablePageFormatters {
             }
         }
 
+        /**
+         * Specify an optional #ICellViewFormatter used to style all table cells.
+         * It is used only when no specific ones are present in the table / column definition.
+         */
         public TablesFormatter setDefaultCellViewFormatter(@Nullable ICellViewFormatter defaultCellViewFormatter) {
             this.defaultCellViewFormatter = defaultCellViewFormatter;
             return this;
@@ -122,6 +151,10 @@ public class TablePageFormatters {
 
         public RowFormatter() { }
 
+        /**
+         *
+         * @param columnNameFormatterPairs a list of {@link String} columnName - #ICellValueFormatter valueFormatter pairs.
+         */
         public RowFormatter setValueFormatters(Object... columnNameFormatterPairs) {
             valueConfig.clear();
             for (int i = 0; i < columnNameFormatterPairs.length; i += 2) {
@@ -137,6 +170,12 @@ public class TablePageFormatters {
             return this;
         }
 
+        /**
+         *
+         * @param columnNameFormatterPairs a list of {@link String} columnName - #ICellViewFormatter headerViewFormatter
+         *                                 - #ICellViewFormatter cellViewFormatter triples.
+         *                                 The view formatters can be null if no specific styling is to be applied.
+         */
         @SuppressWarnings("checkstyle:MagicNumber")
         public RowFormatter setViewFormatters(Object... columnNameFormatterPairs) {
             headerViewConfig.clear();

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -40,8 +40,11 @@ public class TablePageFormatters {
         TablePageFormatters.tablesFormatterFactory = tablesFormatterFactory;
     }
 
+    /**
+     * Used by {@link TablePageAdapter} to get table-specific formatters.
+     */
     @NonNull
-    public static ITablesFormatter createTablesFormatter(Context context) {
+    static ITablesFormatter createTablesFormatter(Context context) {
         if (tablesFormatterFactory != null) {
             return tablesFormatterFactory.create(context);
         } else {
@@ -90,12 +93,16 @@ public class TablePageFormatters {
         String formatValue(Cursor cursor, int col);
     }
 
+    // OPEN: Consider to rename it to ICellStyler, to differentiate it from ICellValueFormatter
     public interface ICellViewFormatter {
         /**
          * Styles a given cell, e.g., width, text appearance, etc.
          * It should not change the actual cell value, which is customized
          * with a #ICellValueFormatter
          */
+        // The parameter needs to be a TextView, rather than just View, so that
+        // TextView-specific styling can be applied.
+        // The downside is implementation could break the contract, and modify the value with TextView#setText()
         void formatView(TextView view);
     }
 

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -42,10 +42,10 @@ public class TablePageFormatters {
         }
     }
 
-    private TablePageFormatters() {} // the class serves as a namespace for the interfaces and default helpers
+    private TablePageFormatters() { } // the class serves as a namespace for the interfaces and default helpers
 
     /**
-     * Provider formatter for a collection of tables
+     * Provider formatter for a collection of tables.
      */
     public interface ITablesFormatter {
         @Nullable
@@ -61,7 +61,7 @@ public class TablePageFormatters {
     }
 
     /**
-     * Format the values of a table row
+     * Format the values of a table row.
      */
     public interface IRowFormatter {
         @Nullable
@@ -91,7 +91,7 @@ public class TablePageFormatters {
                     IRowFormatter formatter = (IRowFormatter) tableNameFormatterPairs[i + 1];
                     config.put(tableName, formatter);
                 } catch (ClassCastException cce) {
-                    throw new IllegalArgumentException("TablesFormatter() - arguments must be in tableName - rowFormatter pairs. Incorrect type at " + i, cce);
+                    throw new IllegalArgumentException("Arguments must be in tableName - rowFormatter pairs. Incorrect type at " + i, cce);
                 }
             }
         }
@@ -119,7 +119,7 @@ public class TablePageFormatters {
         private final Map<String, ICellViewFormatter> headerViewConfig = new ArrayMap<String, ICellViewFormatter>();
         private final Map<String, ICellViewFormatter> viewConfig = new ArrayMap<String, ICellViewFormatter>();
 
-        public RowFormatter() {}
+        public RowFormatter() { }
 
         public RowFormatter setValueFormatters(Object... columnNameFormatterPairs) {
             valueConfig.clear();
@@ -129,12 +129,14 @@ public class TablePageFormatters {
                     ICellValueFormatter cellFormatter = (ICellValueFormatter) columnNameFormatterPairs[i + 1];
                     valueConfig.put(columnName, cellFormatter);
                 } catch (ClassCastException cce) {
-                    throw new IllegalArgumentException("Arguments must be in columnName - cellFormatter pairs. Incorrect type at " + i, cce);
+                    throw new IllegalArgumentException("Arguments must be in columnName - cellFormatter pairs. Incorrect type at " + i,
+                            cce);
                 }
             }
             return this;
         }
 
+        @SuppressWarnings("checkstyle:MagicNumber")
         public RowFormatter setViewFormatters(Object... columnNameFormatterPairs) {
             headerViewConfig.clear();
             viewConfig.clear();
@@ -147,7 +149,9 @@ public class TablePageFormatters {
                     headerViewConfig.put(columnName, headerFormatter);
                     viewConfig.put(columnName, cellFormatter);
                 } catch (ClassCastException cce) {
-                    throw new IllegalArgumentException("Arguments must be in columnName - headerViewFormatter - cellViewFormatter triples. Incorrect type at " + i, cce);
+                    String errMsg = "Arguments must be in columnName - headerViewFormatter - cellViewFormatter triples. "
+                            + "Incorrect type at " + i;
+                    throw new IllegalArgumentException(errMsg, cce);
                 }
             }
             return this;
@@ -184,7 +188,7 @@ public class TablePageFormatters {
 
         @NonNull
         @Override
-        final public String formatValue(Cursor cursor, int col) {
+        public final String formatValue(Cursor cursor, int col) {
             long value = cursor.getLong(col);
             return (value > 0) ? formatter.format(value) : "";
         }
@@ -213,7 +217,7 @@ public class TablePageFormatters {
     }
 
     /**
-     * Use cases: express max width of a view in the unit of dp
+     * Use cases: express max width of a view in the unit of dp.
      * @return the pixels of the given amount of dp
      */
     public static int dpToPx(int dp, @NonNull Context context) {
@@ -221,12 +225,12 @@ public class TablePageFormatters {
     }
 
     /**
-     * Convert a <code>long</code> timestamp to a short date in YY-MM-dd
+     * Convert a <code>long</code> timestamp to a short date in YY-MM-dd.
      */
     public static final ICellValueFormatter shortDate = new DateTimeFormatter("yy-MM-dd");
 
     /**
-     * Convert a <code>long</code> timestamp to a short timestamp string
+     * Convert a <code>long</code> timestamp to a short timestamp string (up to seconds).
      */
     public static final ICellValueFormatter shortTimeStamp = new DateTimeFormatter("yy-MM-dd HH:mm:ss");
 

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -190,7 +190,7 @@ public class TablePageFormatters {
         @Override
         public final String formatValue(Cursor cursor, int col) {
             long value = cursor.getLong(col);
-            return (value > 0) ? formatter.format(value) : "";
+            return value > 0 ? formatter.format(value) : "";
         }
     };
 

--- a/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
+++ b/dbinspector/src/main/java/im/dino/dbinspector/adapters/TablePageFormatters.java
@@ -1,5 +1,6 @@
 package im.dino.dbinspector.adapters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
@@ -179,9 +180,12 @@ public class TablePageFormatters {
     //
 
     public static class DateTimeFormatter implements ICellValueFormatter {
-        //    private static final DateFormat formatter = new SimpleDateFormat("YYYY-MM-dd HH:mm:ss.SSS");
         private final DateFormat formatter;
 
+
+        @SuppressLint("SimpleDateFormat")
+        // SuppressLint reason: the API allows callers to specify the format to present to end users.
+        // Hence locale is the system default, without the need of specifying it.
         public DateTimeFormatter(String formatPattern) {
             formatter = new SimpleDateFormat(formatPattern);
         }


### PR DESCRIPTION
Allows developers to specify custom formatting on per table/column level, which can be used support:
- display of long text (limit max-width of the column and truncate the text), one way for #31 
- display timestamp (unix epoch in `long`) in human-readable format
- human-friendly display of floating point numbers, e.g., limit to 2 decimal places.

See the changes in `ExampleApp.java` for usage.
