### PR TITLE
Remove Stump logger, since it's basically useless

### DIFF
--- a/dbinspector/src/main/kotlin/com/infinum/dbinspector/DbInspector.kt
+++ b/dbinspector/src/main/kotlin/com/infinum/dbinspector/DbInspector.kt
@@ -3,18 +3,19 @@ package com.infinum.dbinspector
 import android.content.Intent
 import com.infinum.dbinspector.ui.Presentation
 import com.infinum.dbinspector.ui.databases.DatabasesActivity
-import com.infinum.dbinspector.ui.shared.logger.Stump
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
 public object DbInspector {
 
+    private var loggerPlanted = false
+
     @JvmStatic
     public fun show() {
 
-        when (BuildConfig.DEBUG) {
-            true -> Timber.plant(DebugTree())
-            false -> Timber.plant(Stump())
+        if (BuildConfig.DEBUG && !loggerPlanted) {
+            loggerPlanted = true
+            Timber.plant(DebugTree())
         }
 
         with(Presentation.applicationContext()) {

--- a/dbinspector/src/main/kotlin/com/infinum/dbinspector/ui/shared/logger/Stump.kt
+++ b/dbinspector/src/main/kotlin/com/infinum/dbinspector/ui/shared/logger/Stump.kt
@@ -1,7 +1,0 @@
-package com.infinum.dbinspector.ui.shared.logger
-
-import timber.log.Timber
-
-internal class Stump : Timber.Tree() {
-    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) = Unit
-}


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/infinum/android_dbinspector/issues) to link here? Or an external link? -->
Stump logger that does nothing is pointless and it's better just to omit planting anything into Timber.

## :pencil: Changes
<!-- Which code did you change? How? -->
Removed Stomp class, planting DebugTree only on debug build and keep "already planted" flag to avoid multiple planted trees on multiple `show()` calls.