### PR TITLE
Standardize Renovate configuration

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,34 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 1,15 * *"
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            android-renovate-config
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@eaf12548c13069dcc28bb75c4ee4610cdbe400c5 # v44.2.6
+        with:
+          token: ${{ steps.app_token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>infinum/android-renovate-config"
+  ],
+  "reviewers": [
+    "KCeh"
+  ]
+}


### PR DESCRIPTION
## Summary
Adopt the shared Renovate setup used across Infinum Android repos:

- `renovate.json` extends the central `infinum/android-renovate-config` preset (no per-repo rules to maintain).
- `.github/workflows/renovate.yml` runs Renovate on a schedule, authenticated with the Renovate GitHub App (not a PAT or the default `GITHUB_TOKEN`).
- Hardened: `permissions: {}` zeroes the default token, the Renovate action is pinned to a full commit SHA, and `RENOVATE_REPOSITORIES` scopes the run to this repo only.

## Prerequisites
The workflow requires, on this repo / org:
- Variable `RENOVATE_APP_ID`
- Secret `RENOVATE_APP_PRIVATE_KEY`
- The Renovate GitHub App installed on this repo **and** on `android-renovate-config` (private preset repo).

## Testing
- Trigger the workflow manually via **Actions → Renovate → Run workflow** (`workflow_dispatch`) and confirm the App token step succeeds and Renovate opens its onboarding/dependency PRs.